### PR TITLE
Feature/handle regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ var rules = [
   {'page': {val: '*', should: true}}
 ];
 ```
+or
+```js
+var rules = [
+  {'page': {val: /.+/, should: true}}
+];
+```
 
 User viewed any page BUT page 3:
 ```js

--- a/lib/rules-engine.js
+++ b/lib/rules-engine.js
@@ -82,8 +82,11 @@ function checkRule(ev, specs) {
           return;
         }
         if (evk === spk) { //if the key if the event is the key of the spec ('views' === 'views')
-          if (typeof sp.val === 'object') { //if the specifications value is an array ('Contains' clause)
-            if (sp.val.length === undefined) {
+          //if the specifications value is an array ('Contains' clause), regexp or object ($ operators)
+          if (typeof sp.val === 'object') {
+            if (sp.val instanceof RegExp) {
+              sp.matched = sp.val.test(event.val) === sp.should;
+            } else if (sp.val.length === undefined) {
               sp.matched = checkComputedRule(sp.val, event.val) === sp.should;
             } else {
               sp.matched = (_.includes(sp.val, event.val) === sp.should) || (sp.should?undefined:false); //or clause get undefined if not found

--- a/tests/simple-usage-spec.js
+++ b/tests/simple-usage-spec.js
@@ -26,6 +26,42 @@ describe('rule engine usage', function() {
       });
   });
 
+  it('should match a simple regexp rule', function(done) {
+    rEngine.apply([{'view': { val: 'abcd' }}], [{'view': {val: /abcd/, should: true}}])
+      .then(function(res){
+        expect(res).toBe(true);
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should match a simple regexp rule with should:false', function(done) {
+    rEngine.apply([{'view': { val: 'abc' }}], [{'view': {val: /abcd/, should: false}}])
+      .then(function(res){
+        expect(res).toBe(true);
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should reject a simple regexp rule', function(done) {
+    rEngine.apply([{'view': { val: 'abcd' }}], [{'view': {val: /dcba/, should: true}}])
+      .then(function(res){
+        expect(res).not.toBe(true);
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('should reject a regexp rule, specified as string', function(done) {
+    rEngine.apply([{'view': { val: 'abcd' }}], [{'view': {val: '/abcd/', should: true}}])
+      .then(function(res){
+        expect(res).not.toBe(true);
+      })
+      .then(done)
+      .catch(done);
+  });
+
   it('should match when found on OR clause', function(done) {
     rEngine.apply([{'view': { val: 1 }}], [{'view': {val: [0, 1, 2], should: true}}])
       .then(function(res){


### PR DESCRIPTION
Add RegExp handling to the engine:

``` js
var rules = [
  {'page': {val: /.+/, should: true}}
];
```

=> accept `page` events, with any value

Fixes #4 

Reviewers: @mrister @jkernech @ky23 

Target release v0.2.0
