### PR TITLE
Feature/array as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,33 @@ var rules = [
   {'clicks': {val: {$gt: 10}, should: true}}
 ];
 ```
+
+
+# OR conditions and optional rules
+You can specify some rules as optional, thus if they don't match, other rules will have priority.
+
+User should do more than 10 clicks OR less than 3 pageviews:
+```js
+var events = [
+ {'clicks': {val: 12}}
+];
+var rules = [
+  {'clicks': {val: {$gt: 10}, should: true, optional: true}},
+  {'views': {val: {$lt: 3}, should: true, optional: true}}
+];
+```
+
+If none are matched, it will be rejected. If one of the two matches, its a true!
+
+You can then make some complex scenario, like:
+User should do more than 10 clicks, AND (views less than 3 pages OR make 1 comment)
+```js
+var events = [
+ {'clicks': {val: 12}}
+];
+var rules = [
+  {'clicks': {val: {$gt: 10}, should: true}},
+  {'views': {val: {$lt: 3}, should: true, optional: true }},
+  {'comments': {val: 1, should: true, optional: true }}
+];
+```

--- a/lib/rules-engine.js
+++ b/lib/rules-engine.js
@@ -98,6 +98,10 @@ function checkRule(ev, specs) {
           } else if (event.val === sp.val && sp.should === false) {
             sp.matched = false;
           }
+
+          if (sp.optional && sp.matched === false) {
+            sp.matched = undefined;
+          }
         }
       });
     });
@@ -122,15 +126,40 @@ function checkRules(params) {
     checkRule(event, params.specs);
   });
 
+  /**
+   * Counters used to count the number of OR condition items, and the number of failed OR conditions
+   * See below for usage and return conditioning
+   * @type {Number}
+   */
+  var total = 0;
+  var optionalFailed = 0;
+
   //now iterate through every specs to check if they are evaluated and if they are all true
   _.each(params.specs, function(spec) {
     _.each(spec, function(sp) {
-      if (sp.matched === undefined) { //if not evaluated, value is should === false
-        sp.matched = (sp.should === false);
+      if (sp.optional) {
+        total++;
       }
+
+      if (sp.matched === undefined && !sp.optional) { //if not evaluated, value is should === false
+        sp.matched = (sp.should === false);
+      } else if (sp.optional && !sp.matched) {
+        sp.matched = true;
+        optionalFailed++;
+      }
+
       result = result && (sp.matched || false); //everything should be true!
     });
   });
+
+  /**
+   * If every single OR rule is a failed condition, then the rule is not correct and we reject it
+   * @param  {Number} total The count of OR conditions
+   * @param  {Number} optionalFailed The count of OR conditions failed
+   */
+  if (total > 0 && total === optionalFailed) {
+    result = false;
+  }
 
   return result;
 }

--- a/lib/rules-engine.js
+++ b/lib/rules-engine.js
@@ -89,8 +89,14 @@ function checkRule(ev, specs) {
             } else if (sp.val.length === undefined) {
               sp.matched = checkComputedRule(sp.val, event.val) === sp.should;
             } else {
-              sp.matched = _.includes(sp.val, event.val) ? sp.should : undefined;
+              if (event.val instanceof Array) {
+                sp.matched = _.intersection(event.val, sp.val).length === event.val.length;
+              } else {
+                sp.matched = _.includes(sp.val, event.val) ? sp.should : undefined;
+              }
             }
+          } else if (event.val instanceof Array) {
+            sp.matched = (_.without(event.val, sp.val).length === 0) === sp.should;
           } else if (sp.val === '*'){ //if the spec should match any value
             sp.matched = sp.should;
           } else if ((event.val === sp.val) === sp.should && sp.should !== false) { //if the spec is made on a regular value

--- a/tests/or-conditions-spec.js
+++ b/tests/or-conditions-spec.js
@@ -1,0 +1,35 @@
+var rEngine = require('../');
+
+describe('rule engine usage', function() {
+  it('should match when one of the OR properties is matched', function(done) {
+    rEngine.apply([{'view': { val: 0 }}], [{ 'view': { val: 0, should: true, optional: true }}, { 'view': { val: 1, should: true, optional: true } }])
+      .then(function(res){
+        expect(res).toBe(true);
+        done();
+      });
+  });
+
+  it('should match when all the OR properties are matched', function(done) {
+    rEngine.apply([{'view': { val: 1 }}], [{ 'view': {val: { $gt: 0 }, should: true, optional: true }}, { 'view': { val: 1, should: true, optional: true } }])
+      .then(function(res){
+        expect(res).toBe(true);
+        done();
+      });
+  });
+
+  it('should not match when all OR conditions are not met (required condition met)', function(done) {
+    rEngine.apply([{'view': { val: 0 }}], [{ 'view': { val: 0, should: true }}, { 'view': { val: 1, should: true, optional: true } }])
+      .then(function(res){
+        expect(res).toBe(false);
+        done();
+      });
+  });
+
+  it('should not match when all OR conditions are not met (only OR)', function(done) {
+    rEngine.apply([{'view': { val: 2 }}], [{ 'view': { val: 0, should: true, optional: true }}, { 'view': { val: 1, should: true, optional: true } }])
+      .then(function(res){
+        expect(res).toBe(false);
+        done();
+      });
+  });
+});

--- a/tests/simple-usage-spec.js
+++ b/tests/simple-usage-spec.js
@@ -167,4 +167,46 @@ describe('rule engine usage', function() {
         });
     });
   });
+
+  describe('with arrays', function() {
+    it('should be able to match provided values as array, spec as number', function(done) {
+      rEngine.apply([{'view': { val: [1] }}], [{'view': {val: 1, should: true }}])
+        .then(function(res){
+          expect(res).toBe(true);
+          done();
+        });
+    });
+
+    it('should not be able to match provided values as array, spec as number', function(done) {
+      rEngine.apply([{'view': { val: [4] }}], [{'view': {val: 1, should: true }}])
+        .then(function(res){
+          expect(res).toBe(false);
+          done();
+        });
+    });
+
+    it('should be able to match provided values as array, spec as array', function(done) {
+      rEngine.apply([{'view': { val: [1, 2, 3] }}], [{'view': {val: [1, 2, 3, 4], should: true }}])
+        .then(function(res){
+          expect(res).toBe(true);
+          done();
+        });
+    });
+
+    it('should not be able to match provided values as array, spec as array', function(done) {
+      rEngine.apply([{'view': { val: [1, 2, 3, 4] }}], [{'view': {val: [1], should: true }}])
+        .then(function(res){
+          expect(res).toBe(false);
+          done();
+        });
+    });
+
+    it('should not be able to match provided values as array, spec as array', function(done) {
+      rEngine.apply([{'view': { val: [4, 3] }}], [{'view': {val: [1, 2], should: true }}])
+        .then(function(res){
+          expect(res).toBe(false);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
Based on #7 

This feature add a new feature to the rule engine, and allow usage of array as input parameter. Now we can do:

```js
      rEngine.apply([{'view': { val: [1, 2, 3] }}], [{'view': {val: [1, 2, 3], should: true }}]);
```

And it will try to match arrays. It does a comparison based on the input param, for example, this works:
```js
      rEngine.apply([{'view': { val: [1, 2] }}], [{'view': {val: [1, 2, 3], should: true }}]);
```

But this does not work:
```js
      rEngine.apply([{'view': { val: [1, 2, 3] }}], [{'view': {val: [1, 2], should: true }}]);
```


